### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,22 @@
 {
     "name": "CopilotAdventures",
+
+    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0-noble",
+
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:latest": {},
+        "ghcr.io/devcontainers/features/dotnet:latest": {
+            "version": "9.0"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:latest": {},
+        "ghcr.io/devcontainers/features/node:latest": {},
+        "ghcr.io/devcontainers/features/python:latest": {}
+    },
+
+    "overrideFeatureInstallOrder": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ],
+
     // Configure tool-specific properties.
     "customizations": {
         "vscode": {


### PR DESCRIPTION
Currently `devcontainer.json` has the default container image settings. However, when a GH Codespace instance is launched, it throws a few errors and lacks a couple of features. This PR is:

- To add .NET SDK 8 and 9
- To add the latest version of Python 3.12.x
- To add the latest version of node.js LTS
- To add docker-in-docker feature for adding container-based MCP servers
